### PR TITLE
Update setupreg.sh: HKEY_CLASSES_ROOT\XLaunch.cygwin\Shell\Open\command doen't work

### DIFF
--- a/setupreg.sh
+++ b/setupreg.sh
@@ -6,8 +6,8 @@
 
 # program to invoke
 prog="\"$(cygpath -w $(which run))\" --quote"
-opencmd="\"$(cygpath -w $(which bash))\" -l -c \"xlaunch -run  \\\"%1\\\"\""
-editcmd="\"$(cygpath -w $(which bash))\" -l -c \"xlaunch -load \\\"%1\\\"\""
+opencmd="\"$(cygpath -w $(which bash))\" '-l -c \"xlaunch -run $(cygpath '%1')\"&'"
+editcmd="\"$(cygpath -w $(which bash))\" '-l -c \"xlaunch -load $(cygpath '%1')\"&'"
 
 # document icon to use
 # (we must set this or we get the run icon, which isn't what we want)


### PR DESCRIPTION
1. %1 must be cygpathed
2. 'run' does not work fine with multiple arguments: then we have to encote bash arguments.
3. I don't know why, but 'run' waits for bash (without -wait argument): Launching xlaunch in background.

Changes not tested. I have only tested commands by editing my HKEY_CLASSES_ROOT keys.